### PR TITLE
Improve Jina tools relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ An MCP server that provides access to Jina AI's powerful web services through Cl
 - Options for including links and images
 - Ability to generate alt text for images
 - Cache control options
+- Requires a query and returns the five most relevant chunks using Jina embeddings
 
 #### `search_web`
 - Search the web using Jina AI's search API
 - Configurable number of results (default: 5)
 - Support for image retention and alt text generation
 - Multiple return formats (markdown, text, html)
-- Returns structured results with titles, descriptions, and content
+- Returns structured results with titles, descriptions, and the five most relevant content chunks
 
 #### `fact_check`
 - Fact-check statements using Jina AI's grounding engine

--- a/schemas.ts
+++ b/schemas.ts
@@ -87,6 +87,32 @@ export const GroundingResponseSchema = z.object({
   })
 });
 
+// Embedding schemas
+export const EmbeddingResponseSchema = z.union([
+  z.object({
+    data: z.array(
+      z.object({
+        embedding: z.array(z.number()),
+        index: z.number().optional(),
+        object: z.string().optional()
+      })
+    ),
+    model: z.string().optional(),
+    object: z.string().optional(),
+    usage: z
+      .object({
+        total_tokens: z.number().optional(),
+        prompt_tokens: z.number().optional()
+      })
+      .optional()
+  }),
+  z.object({
+    embeddings: z.array(z.array(z.number()))
+  })
+]);
+
+export type EmbeddingResponse = z.infer<typeof EmbeddingResponseSchema>;
+
 export type ReaderRequest = z.infer<typeof ReaderRequestSchema>;
 export type ReaderResponse = z.infer<typeof ReaderResponseSchema>;
 export type SearchWebRequest = z.infer<typeof SearchWebSchema>;


### PR DESCRIPTION
## Summary
- add embedding response schema and typed helpers for Jina endpoints
- rename chunk helper and validate text before embedding
- require a query for webpages and return five best chunks
- select the five most relevant chunks in search results
- document query requirement and new chunk-based responses

## Testing
- `npm run build`
