### PR TITLE
Handle embedding token limits

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -88,17 +88,61 @@ function chunkText(text: string, chunkSize = 200): string[] {
   return chunks;
 }
 
-// Generate embeddings using Jina AI with basic validation
+// Token limit for a single embedding request (approximate)
+const EMBEDDING_TOKEN_LIMIT = 8192;
+
+/**
+ * Rough token estimator based on character count.
+ * A token is approximated as 0.75 characters.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length * 0.75);
+}
+
+// Generate embeddings using Jina AI with basic validation and batching
 async function embedTexts(texts: string[]): Promise<number[][]> {
   const trimmed = texts.map((t) => t.trim()).filter((t) => t !== "");
   if (trimmed.length === 0) {
     return [];
   }
-  const response = await embedJina(trimmed);
-  if ("data" in response) {
-    return response.data.map((d) => d.embedding);
+
+  const results: number[][] = [];
+  let batch: string[] = [];
+  let tokens = 0;
+
+  const processBatch = async () => {
+    if (batch.length === 0) return;
+    const response = await embedJina(batch);
+    const embeddings = "data" in response
+      ? response.data.map((d) => d.embedding)
+      : response.embeddings;
+    results.push(...embeddings);
+    batch = [];
+    tokens = 0;
+  };
+
+  for (const text of trimmed) {
+    const count = estimateTokens(text);
+    if (count > EMBEDDING_TOKEN_LIMIT) {
+      console.warn(
+        `Text starting with "${text.substring(0, 50)}..." has an estimated ${count} tokens, exceeding the limit of ${EMBEDDING_TOKEN_LIMIT}. It will be skipped.`
+      );
+      continue;
+    }
+
+    if (tokens + count > EMBEDDING_TOKEN_LIMIT && batch.length > 0) {
+      await processBatch();
+    }
+
+    batch.push(text);
+    tokens += count;
   }
-  return response.embeddings;
+
+  if (batch.length > 0) {
+    await processBatch();
+  }
+
+  return results;
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {


### PR DESCRIPTION
## Summary
- add batching logic for embedding calls
- estimate tokens and split requests to stay under 8192 tokens per call
- skip oversized texts and refactor batch processing

## Testing
- `npm run build`
